### PR TITLE
SDK getResource query params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zowe/cics_monorepo",
-  "version": "6.0.2",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zowe/cics_monorepo",
-      "version": "6.0.2",
+      "version": "6.1.0",
       "workspaces": [
         "packages/*"
       ],
@@ -15711,13 +15711,13 @@
     },
     "packages/cli": {
       "name": "@zowe/cics-for-zowe-cli",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "bundleDependencies": [
         "@zowe/cics-for-zowe-sdk"
       ],
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/cics-for-zowe-sdk": "6.0.0"
+        "@zowe/cics-for-zowe-sdk": "6.1.0"
       },
       "engines": {
         "node": ">=18.12.0"
@@ -15728,7 +15728,7 @@
     },
     "packages/sdk": {
       "name": "@zowe/cics-for-zowe-sdk",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "license": "EPL-2.0",
       "dependencies": {
         "xml2js": "0.5.0"
@@ -15762,9 +15762,9 @@
     },
     "packages/vsce": {
       "name": "cics-extension-for-zowe",
-      "version": "3.0.2",
+      "version": "3.1.0",
       "dependencies": {
-        "@zowe/cics-for-zowe-sdk": "6.0.0",
+        "@zowe/cics-for-zowe-sdk": "6.1.0",
         "@zowe/core-for-zowe-sdk": "^8.0.0",
         "@zowe/zowe-explorer-api": "^3.0.3",
         "axios": "^1.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zowe/cics_monorepo",
   "private": true,
-  "version": "6.0.2",
+  "version": "6.1.0",
   "publishConfig": {
     "registry": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/cics-for-zowe-cli",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "author": "Zowe",
   "license": "EPL-2.0",
   "description": "IBM CICS Plug-in for Zowe CLI",
@@ -51,7 +51,7 @@
     "configurationModule": "lib/imperative.js"
   },
   "dependencies": {
-    "@zowe/cics-for-zowe-sdk": "6.0.0"
+    "@zowe/cics-for-zowe-sdk": "6.1.0"
   },
   "peerDependencies": {
     "@zowe/imperative": "^8.0.0"

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® CICS® Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Add optional query parameters on getResource SDK method. [#168](https://github.com/zowe/cics-for-zowe-client/issues/168)
+
 ## `6.1.0`
 
 - Enhancement: Made the region name optional on the getResource SDK method. [#162](https://github.com/zowe/cics-for-zowe-client/issues/162)

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the IBM® CICS® Plug-in for Zowe CLI will be documented in this file.
 
-## Recent Changes
+## `6.1.0`
 
 - Enhancement: Made the region name optional on the getResource SDK method. [#162](https://github.com/zowe/cics-for-zowe-client/issues/162)
 

--- a/packages/sdk/__tests__/__unit__/get/Get.resource.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/get/Get.resource.unit.test.ts
@@ -184,5 +184,74 @@ describe("CMCI - Get resource", () => {
       expect(response).toContain(content);
       expect(deleteSpy).toHaveBeenCalledWith(dummySession, endPoint, []);
     });
+
+    it("should be able to get a resource with SUMMONLY specified", async () => {
+      resourceParms.cicsPlex = "plex1";
+      resourceParms.regionName = "reg1";
+      resourceParms.queryParams = {
+        summonly: true,
+      };
+      endPoint = `/${CicsCmciConstants.CICS_SYSTEM_MANAGEMENT}/${resource}/plex1/reg1?SUMMONLY`;
+      response = await getResource(dummySession, resourceParms);
+
+      expect(response).toContain(content);
+      expect(deleteSpy).toHaveBeenCalledWith(dummySession, endPoint, []);
+    });
+
+    it("should be able to get a resource with NODISCARD specified", async () => {
+      resourceParms.cicsPlex = "plex1";
+      resourceParms.regionName = "reg1";
+      resourceParms.queryParams = {
+        nodiscard: true,
+      };
+      endPoint = `/${CicsCmciConstants.CICS_SYSTEM_MANAGEMENT}/${resource}/plex1/reg1?NODISCARD`;
+      response = await getResource(dummySession, resourceParms);
+
+      expect(response).toContain(content);
+      expect(deleteSpy).toHaveBeenCalledWith(dummySession, endPoint, []);
+    });
+
+    it("should be able to get a resource with OVERRIDEWARNINGCOUNT specified", async () => {
+      resourceParms.cicsPlex = "plex1";
+      resourceParms.regionName = "reg1";
+      resourceParms.queryParams = {
+        overrideWarningCount: true,
+      };
+      endPoint = `/${CicsCmciConstants.CICS_SYSTEM_MANAGEMENT}/${resource}/plex1/reg1?OVERRIDEWARNINGCOUNT`;
+      response = await getResource(dummySession, resourceParms);
+
+      expect(response).toContain(content);
+      expect(deleteSpy).toHaveBeenCalledWith(dummySession, endPoint, []);
+    });
+
+    it("should be able to get a resource with all query params specified", async () => {
+      resourceParms.cicsPlex = "plex1";
+      resourceParms.regionName = "reg1";
+      resourceParms.queryParams = {
+        overrideWarningCount: true,
+        summonly: true,
+        nodiscard: true,
+      };
+      endPoint = `/${CicsCmciConstants.CICS_SYSTEM_MANAGEMENT}/${resource}/plex1/reg1?SUMMONLY&NODISCARD&OVERRIDEWARNINGCOUNT`;
+      response = await getResource(dummySession, resourceParms);
+
+      expect(response).toContain(content);
+      expect(deleteSpy).toHaveBeenCalledWith(dummySession, endPoint, []);
+    });
+
+    it("should be able to get a resource with no context and all query params specified", async () => {
+      resourceParms.cicsPlex = undefined;
+      resourceParms.regionName = undefined;
+      resourceParms.queryParams = {
+        overrideWarningCount: true,
+        summonly: true,
+        nodiscard: true,
+      };
+      endPoint = `/${CicsCmciConstants.CICS_SYSTEM_MANAGEMENT}/${resource}/?SUMMONLY&NODISCARD&OVERRIDEWARNINGCOUNT`;
+      response = await getResource(dummySession, resourceParms);
+
+      expect(response).toContain(content);
+      expect(deleteSpy).toHaveBeenCalledWith(dummySession, endPoint, []);
+    });
   });
 });

--- a/packages/sdk/__tests__/__unit__/utils/Utils.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/utils/Utils.unit.test.ts
@@ -223,5 +223,195 @@ describe("Utils - getResourceUri", () => {
       expect(error).toBeUndefined();
       expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/region1?CRITERIA=(NAME%3Dtest1)&PARAMETER=PARAM%3Dtest2");
     });
+
+    it("should be able to get a resource uri with SUMMONLY specified", async () => {
+      try {
+        const options: IGetResourceUriOptions = {
+          cicsPlex: "cicsplex1",
+          regionName: "region1",
+          queryParams: {
+            summonly: true,
+          }
+        };
+
+        response = Utils.getResourceUri("resource1", options);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/region1?SUMMONLY");
+    });
+
+    it("should be able to get a resource uri with SUMMONLY specified to false", async () => {
+      try {
+        const options: IGetResourceUriOptions = {
+          cicsPlex: "cicsplex1",
+          regionName: "region1",
+          queryParams: {
+            summonly: false,
+          }
+        };
+
+        response = Utils.getResourceUri("resource1", options);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/region1");
+    });
+
+    it("should be able to get a resource uri with NODISCARD specified", async () => {
+      try {
+        const options: IGetResourceUriOptions = {
+          cicsPlex: "cicsplex1",
+          regionName: "region1",
+          queryParams: {
+            nodiscard: true,
+          }
+        };
+
+        response = Utils.getResourceUri("resource1", options);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/region1?NODISCARD");
+    });
+
+    it("should be able to get a resource uri with NODISCARD specified", async () => {
+      try {
+        const options: IGetResourceUriOptions = {
+          cicsPlex: "cicsplex1",
+          regionName: "region1",
+          queryParams: {
+            nodiscard: false,
+          }
+        };
+
+        response = Utils.getResourceUri("resource1", options);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/region1");
+    });
+
+    it("should be able to get a resource uri with OVERRIDEWARNINGCOUNT specified", async () => {
+      try {
+        const options: IGetResourceUriOptions = {
+          cicsPlex: "cicsplex1",
+          regionName: "region1",
+          queryParams: {
+            overrideWarningCount: true,
+          }
+        };
+
+        response = Utils.getResourceUri("resource1", options);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/region1?OVERRIDEWARNINGCOUNT");
+    });
+
+    it("should be able to get a resource uri with OVERRIDEWARNINGCOUNT specified to false", async () => {
+      try {
+        const options: IGetResourceUriOptions = {
+          cicsPlex: "cicsplex1",
+          regionName: "region1",
+          queryParams: {
+            overrideWarningCount: false,
+          }
+        };
+
+        response = Utils.getResourceUri("resource1", options);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/region1");
+    });
+
+    it("should be able to get a resource uri with all query params specified", async () => {
+      try {
+        const options: IGetResourceUriOptions = {
+          cicsPlex: "cicsplex1",
+          regionName: "region1",
+          queryParams: {
+            summonly: true,
+            nodiscard: true,
+            overrideWarningCount: true,
+          }
+        };
+
+        response = Utils.getResourceUri("resource1", options);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/region1?SUMMONLY&NODISCARD&OVERRIDEWARNINGCOUNT");
+    });
+
+    it("should be able to get a resource uri with all query params specified and no context", async () => {
+      try {
+        const options: IGetResourceUriOptions = {
+          queryParams: {
+            summonly: true,
+            nodiscard: true,
+            overrideWarningCount: true,
+          }
+        };
+
+        response = Utils.getResourceUri("resource1", options);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/?SUMMONLY&NODISCARD&OVERRIDEWARNINGCOUNT");
+    });
+  });
+});
+
+describe('Utils - enforceParentheses', () => {
+
+  it("should add brackets when none exist", () => {
+    const output = Utils.enforceParentheses("input");
+    expect(output).toEqual("(input)");
+  });
+
+  it("should add first bracket when end exists", () => {
+    const output = Utils.enforceParentheses("input with spaces)");
+    expect(output).toEqual("(input with spaces)");
+  });
+
+  it("should add last bracket when first exists", () => {
+    const output = Utils.enforceParentheses("(input with spec1@| characters");
+    expect(output).toEqual("(input with spec1@| characters)");
+  });
+
+  it("should do nothing when both brackets exist", () => {
+    const output = Utils.enforceParentheses("(fully covered)");
+    expect(output).toEqual("(fully covered)");
+  });
+
+  it("should do nothing when multiple brackets exist", () => {
+    const output = Utils.enforceParentheses("((()))");
+    expect(output).toEqual("((()))");
   });
 });

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/cics-for-zowe-sdk",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "author": "Zowe",
   "license": "EPL-2.0",
   "description": "IBM CICS for Zowe SDK",

--- a/packages/sdk/src/constants/CicsCmci.constants.ts
+++ b/packages/sdk/src/constants/CicsCmci.constants.ts
@@ -12,7 +12,7 @@
 /**
  * Constants to be used by the API
  */
-export const CicsCmciConstants: { [key: string]: any } = {
+export const CicsCmciConstants = {
   /**
      * Specifies the required part of the REST interface URI
      */
@@ -78,6 +78,11 @@ export const CicsCmciConstants: { [key: string]: any } = {
      * NODISCARD parameter
      */
   NO_DISCARD: "NODISCARD",
+
+  /**
+     * OVERRIDEWARNINGCOUNT parameter
+     */
+  OVERRIDE_WARNING_COUNT: "OVERRIDEWARNINGCOUNT",
 
   /**
      * CRITERIA parameter

--- a/packages/sdk/src/doc/IGetResourceUriOptions.ts
+++ b/packages/sdk/src/doc/IGetResourceUriOptions.ts
@@ -9,6 +9,8 @@
  *
  */
 
+import { IResourceQueryParams } from "./IResourceQueryParms";
+
 export interface IGetResourceUriOptions {
 
   /**
@@ -39,4 +41,9 @@ export interface IGetResourceUriOptions {
     *    "CSDGROUP(D*)"
     */
   parameter?: string;
+
+  /**
+   *  Query parameters to be used in the HTTP request
+   */
+  queryParams?: IResourceQueryParams;
 }

--- a/packages/sdk/src/doc/IResourceParms.ts
+++ b/packages/sdk/src/doc/IResourceParms.ts
@@ -9,38 +9,11 @@
  *
  */
 
-export interface IResourceParms {
+import { IGetResourceUriOptions } from "./IGetResourceUriOptions";
+
+export interface IResourceParms extends IGetResourceUriOptions {
   /**
      * The name of the resource
      */
   name: string;
-
-  /**
-     * Criteria by which to filter the records
-     *
-     * Examples:
-     *    "TRANID=TRAN"
-     *    "PROGRAM=PRG*"
-     *    "NAME=C* AND PROGRAM=D*"
-     */
-  criteria?: string;
-
-  /**
-     * Parameter by which to refine the records
-     *
-     * Example:
-     *    "CSDGROUP(GRP1)"
-     *    "CSDGROUP(D*)"
-     */
-  parameter?: string;
-
-  /**
-     * The name of the CICS region of the program
-     */
-  regionName?: string;
-
-  /**
-     * CICS Plex of the program
-     */
-  cicsPlex?: string;
 }

--- a/packages/sdk/src/doc/IResourceQueryParms.ts
+++ b/packages/sdk/src/doc/IResourceQueryParms.ts
@@ -1,0 +1,25 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+export interface IResourceQueryParams {
+  /**
+   * Include SUMMONLY query parameter
+   */
+  summonly?: boolean;
+  /**
+   * Include NODISCARD query parameter
+   */
+  nodiscard?: boolean;
+  /**
+   * Include OVERRIDEWARNINGCOUNT query parameter
+   */
+  overrideWarningCount?: boolean;
+}

--- a/packages/sdk/src/methods/get/Get.ts
+++ b/packages/sdk/src/methods/get/Get.ts
@@ -10,8 +10,8 @@
  */
 
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
+import { ICMCIApiResponse, IGetResourceUriOptions, IResourceParms } from "../../doc";
 import { CicsCmciRestClient } from "../../rest";
-import { ICMCIApiResponse, IResourceParms, IGetResourceUriOptions } from "../../doc";
 import { Utils } from "../../utils";
 
 /**
@@ -30,10 +30,11 @@ export async function getResource(session: AbstractSession, parms: IResourceParm
   Logger.getAppLogger().debug("Attempting to get resource(s) with the following parameters:\n%s", JSON.stringify(parms));
 
   const options: IGetResourceUriOptions = {
-    "cicsPlex": parms.cicsPlex,
-    "regionName": parms.regionName,
-    "criteria": parms.criteria,
-    "parameter": parms.parameter
+    cicsPlex: parms.cicsPlex,
+    regionName: parms.regionName,
+    criteria: parms.criteria,
+    parameter: parms.parameter,
+    queryParams: parms.queryParams,
   };
 
   const cmciResource = Utils.getResourceUri(parms.name, options);

--- a/packages/sdk/src/utils/Utils.ts
+++ b/packages/sdk/src/utils/Utils.ts
@@ -25,7 +25,7 @@ export class Utils {
    * @param {string} resourceName - CMCI resource name
    * @param {IGetResourceUriOptions} options - CMCI resource options
    */
-  public static getResourceUri(resourceName: string, options?: IGetResourceUriOptions) : string {
+  public static getResourceUri(resourceName: string, options?: IGetResourceUriOptions): string {
     ImperativeExpect.toBeDefinedAndNonBlank(resourceName, "CICS Resource name", "CICS resource name is required");
 
     let delimiter = "?"; // initial delimiter
@@ -35,20 +35,42 @@ export class Utils {
 
     let cmciResource = `/${CicsCmciConstants.CICS_SYSTEM_MANAGEMENT}/${resourceName}/${cicsPlex}${region}`;
 
-    if (options != null) {
-      if (options.criteria != null && options.criteria.length > 0) {
-        const addParentheses = options.criteria.charAt(0) !== '(';
+    if (options && options.criteria) {
+      cmciResource += `${delimiter}${CicsCmciConstants.CRITERIA}=${this.enforceParentheses(encodeURIComponent(options.criteria))}`;
+      delimiter = "&";
+    }
 
-        cmciResource = cmciResource + delimiter + "CRITERIA=" + (addParentheses ? "(": "") +
-        encodeURIComponent(options.criteria) + (addParentheses ? ")": "") ;
-        delimiter = "&";
-      }
+    if (options && options.parameter) {
+      cmciResource += `${delimiter}PARAMETER=${encodeURIComponent(options.parameter)}`;
+      delimiter = "&";
+    }
 
-      if (options.parameter != null && options.parameter.length > 0) {
-        cmciResource = cmciResource + delimiter + "PARAMETER=" + encodeURIComponent(options.parameter);
-      }
+    if (options && options.queryParams && options.queryParams.summonly) {
+      cmciResource += `${delimiter}${CicsCmciConstants.SUMM_ONLY}`;
+      delimiter = "&";
+    }
+
+    if (options && options.queryParams && options.queryParams.nodiscard) {
+      cmciResource += `${delimiter}${CicsCmciConstants.NO_DISCARD}`;
+      delimiter = "&";
+    }
+
+    if (options && options.queryParams && options.queryParams.overrideWarningCount) {
+      cmciResource += `${delimiter}${CicsCmciConstants.OVERRIDE_WARNING_COUNT}`;
+      delimiter = "&";
     }
 
     return cmciResource;
+  }
+
+  public static enforceParentheses(input: string): string {
+    if (!input.startsWith('(') && !input.endsWith(')')) {
+      return `(${input})`;
+    } else if (input.startsWith('(') && !input.endsWith(')')) {
+      return `${input})`;
+    } else if (!input.startsWith('(') && input.endsWith(')')) {
+      return `(${input}`;
+    }
+    return input;
   }
 }

--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/zowe/cics-for-zowe-client.git"
   },
-  "version": "3.0.2",
+  "version": "3.1.0",
   "engines": {
     "vscode": "^1.79.0"
   },
@@ -892,7 +892,7 @@
     "@vscode/vsce": "^2.32.0"
   },
   "dependencies": {
-    "@zowe/cics-for-zowe-sdk": "6.0.0",
+    "@zowe/cics-for-zowe-sdk": "6.1.0",
     "@zowe/core-for-zowe-sdk": "^8.0.0",
     "@zowe/zowe-explorer-api": "^3.0.3",
     "axios": "^1.6.7",


### PR DESCRIPTION
**What It Does**

Resolves zowe/cics-for-zowe-client#168

Adds query parameters (SUMMONLY, NODISCARD, OVERRIDEWARNINGCOUNT) to the getResource SDK method. Adds unit tests for added methods / functionality.

Allows VSCE to get cache tokens back from CMCI requests using getResource method.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
