### PR TITLE
Fix CICS connections breaking other ZE sessions

### DIFF
--- a/packages/vsce/src/commands/closeLocalFileCommand.ts
+++ b/packages/vsce/src/commands/closeLocalFileCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSTree } from "../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSLocalFileTreeItem } from "../trees/treeItems/CICSLocalFileTreeItem";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
@@ -52,8 +51,6 @@ export function getCloseLocalFileCommand(tree: CICSTree, treeview: TreeView<any>
             });
             const currentNode = allSelectedNodes[parseInt(index)];
 
-            https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
             try {
               await closeLocalFile(
                 currentNode.parentRegion.parentSession.session,
@@ -64,20 +61,17 @@ export function getCloseLocalFileCommand(tree: CICSTree, treeview: TreeView<any>
                 },
                 busyDecision
               );
-              https.globalAgent.options.rejectUnauthorized = undefined;
               if (!parentRegions.includes(currentNode.parentRegion)) {
                 parentRegions.push(currentNode.parentRegion);
               }
             } catch (error) {
-              https.globalAgent.options.rejectUnauthorized = undefined;
               // @ts-ignore
               if (error.mMessage) {
                 // @ts-ignore
                 const [_, resp2, respAlt, eibfnAlt] = splitCmciErrorMessage(error.mMessage);
 
                 window.showErrorMessage(
-                  `Perform CLOSE on local file "${
-                    allSelectedNodes[parseInt(index)].localFile.file
+                  `Perform CLOSE on local file "${allSelectedNodes[parseInt(index)].localFile.file
                   }" failed: EXEC CICS command (${eibfnAlt}) RESP(${respAlt}) RESP2(${resp2})`
                 );
               } else {
@@ -124,7 +118,7 @@ export function getCloseLocalFileCommand(tree: CICSTree, treeview: TreeView<any>
 
 async function closeLocalFile(
   session: imperative.AbstractSession,
-  parms: { name: string; regionName: string; cicsPlex: string },
+  parms: { name: string; regionName: string; cicsPlex: string; },
   busyDecision: string
 ): Promise<ICMCIApiResponse> {
   const requestBody: any = {

--- a/packages/vsce/src/commands/disableCommands/disableLocalFileCommand.ts
+++ b/packages/vsce/src/commands/disableCommands/disableLocalFileCommand.ts
@@ -52,8 +52,6 @@ export function getDisableLocalFileCommand(tree: CICSTree, treeview: TreeView<an
             });
             const currentNode = allSelectedNodes[parseInt(index)];
 
-            https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
             try {
               await disableLocalFile(
                 currentNode.parentRegion.parentSession.session,
@@ -64,12 +62,10 @@ export function getDisableLocalFileCommand(tree: CICSTree, treeview: TreeView<an
                 },
                 busyDecision
               );
-              https.globalAgent.options.rejectUnauthorized = undefined;
               if (!parentRegions.includes(currentNode.parentRegion)) {
                 parentRegions.push(currentNode.parentRegion);
               }
             } catch (error) {
-              https.globalAgent.options.rejectUnauthorized = undefined;
               window.showErrorMessage(
                 `Something went wrong when performing a DISABLE - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(
                   /(\\n\t|\\n|\\t)/gm,

--- a/packages/vsce/src/commands/disableCommands/disableProgramCommand.ts
+++ b/packages/vsce/src/commands/disableCommands/disableProgramCommand.ts
@@ -50,7 +50,6 @@ export function getDisableProgramCommand(tree: CICSTree, treeview: TreeView<any>
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
           try {
             await disableProgram(currentNode.parentRegion.parentSession.session, {
@@ -58,12 +57,10 @@ export function getDisableProgramCommand(tree: CICSTree, treeview: TreeView<any>
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             // @ts-ignore
             window.showErrorMessage(
               `Something went wrong when performing a disable - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(

--- a/packages/vsce/src/commands/disableCommands/disableTransactionCommand.ts
+++ b/packages/vsce/src/commands/disableCommands/disableTransactionCommand.ts
@@ -45,7 +45,6 @@ export function getDisableTransactionCommand(tree: CICSTree, treeview: TreeView<
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
           try {
             await disableTransaction(currentNode.parentRegion.parentSession.session, {
@@ -53,12 +52,10 @@ export function getDisableTransactionCommand(tree: CICSTree, treeview: TreeView<
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             // @ts-ignore
             if (error.mMessage) {
               // @ts-ignore

--- a/packages/vsce/src/commands/enableCommands/enableLocalFileCommand.ts
+++ b/packages/vsce/src/commands/enableCommands/enableLocalFileCommand.ts
@@ -45,7 +45,6 @@ export function getEnableLocalFileCommand(tree: CICSTree, treeview: TreeView<any
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
           try {
             await enableLocalFile(currentNode.parentRegion.parentSession.session, {
@@ -53,12 +52,10 @@ export function getEnableLocalFileCommand(tree: CICSTree, treeview: TreeView<any
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             window.showErrorMessage(
               `Something went wrong when performing an ENABLE - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(
                 /(\\n\t|\\n|\\t)/gm,

--- a/packages/vsce/src/commands/enableCommands/enableProgramCommand.ts
+++ b/packages/vsce/src/commands/enableCommands/enableProgramCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../../trees/CICSRegionTree";
 import { CICSTree } from "../../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { CICSProgramTreeItem } from "../../trees/treeItems/CICSProgramTreeItem";
 import { findSelectedNodes } from "../../utils/commandUtils";
@@ -50,20 +49,16 @@ export function getEnableProgramCommand(tree: CICSTree, treeview: TreeView<any>)
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
           try {
             await enableProgram(currentNode.parentRegion.parentSession.session, {
               name: currentNode.program.program,
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             window.showErrorMessage(
               `Something went wrong when performing an ENABLE - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(
                 /(\\n\t|\\n|\\t)/gm,
@@ -104,7 +99,7 @@ export function getEnableProgramCommand(tree: CICSTree, treeview: TreeView<any>)
   });
 }
 
-async function enableProgram(session: imperative.AbstractSession, parms: { name: string; regionName: string; cicsPlex: string }): Promise<ICMCIApiResponse> {
+async function enableProgram(session: imperative.AbstractSession, parms: { name: string; regionName: string; cicsPlex: string; }): Promise<ICMCIApiResponse> {
   const requestBody: any = {
     request: {
       action: {

--- a/packages/vsce/src/commands/enableCommands/enableTransactionCommand.ts
+++ b/packages/vsce/src/commands/enableCommands/enableTransactionCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../../trees/CICSRegionTree";
 import { CICSTree } from "../../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { findSelectedNodes } from "../../utils/commandUtils";
 import { CICSTransactionTreeItem } from "../../trees/treeItems/CICSTransactionTreeItem";
@@ -46,7 +45,6 @@ export function getEnableTransactionCommand(tree: CICSTree, treeview: TreeView<a
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
           try {
             await enableTransaction(currentNode.parentRegion.parentSession.session, {
@@ -54,12 +52,10 @@ export function getEnableTransactionCommand(tree: CICSTree, treeview: TreeView<a
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             window.showErrorMessage(
               `Something went wrong when performing an ENABLE - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(
                 /(\\n\t|\\n|\\t)/gm,
@@ -99,7 +95,7 @@ export function getEnableTransactionCommand(tree: CICSTree, treeview: TreeView<a
   });
 }
 
-async function enableTransaction(session: imperative.AbstractSession, parms: { name: string; regionName: string; cicsPlex: string }): Promise<ICMCIApiResponse> {
+async function enableTransaction(session: imperative.AbstractSession, parms: { name: string; regionName: string; cicsPlex: string; }): Promise<ICMCIApiResponse> {
   const requestBody: any = {
     request: {
       action: {

--- a/packages/vsce/src/commands/newCopyCommand.ts
+++ b/packages/vsce/src/commands/newCopyCommand.ts
@@ -13,7 +13,6 @@ import { programNewcopy } from "@zowe/cics-for-zowe-sdk";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSTree } from "../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSProgramTreeItem } from "../trees/treeItems/CICSProgramTreeItem";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
@@ -49,28 +48,23 @@ export function getNewCopyCommand(tree: CICSTree, treeview: TreeView<any>) {
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
           try {
             await programNewcopy(currentNode.parentRegion.parentSession.session, {
               name: currentNode.program.program,
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
             // CMCI new copy error
-            https.globalAgent.options.rejectUnauthorized = undefined;
             // @ts-ignore
             if (error.mMessage) {
               // @ts-ignore
               const [_, resp2, respAlt, eibfnAlt] = splitCmciErrorMessage(error.mMessage);
               window.showErrorMessage(
-                `Perform NEWCOPY on Program "${
-                  allSelectedNodes[parseInt(index)].program.program
+                `Perform NEWCOPY on Program "${allSelectedNodes[parseInt(index)].program.program
                 }" failed: EXEC CICS command (${eibfnAlt}) RESP(${respAlt}) RESP2(${resp2})`
               );
             } else {

--- a/packages/vsce/src/commands/openLocalFileCommand.ts
+++ b/packages/vsce/src/commands/openLocalFileCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSTree } from "../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSLocalFileTreeItem } from "../trees/treeItems/CICSLocalFileTreeItem";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
@@ -45,27 +44,22 @@ export function getOpenLocalFileCommand(tree: CICSTree, treeview: TreeView<any>)
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
           try {
             await openLocalFile(currentNode.parentRegion.parentSession.session, {
               name: currentNode.localFile.file,
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             // @ts-ignore
             if (error.mMessage) {
               // @ts-ignore
               const [_, resp2, respAlt, eibfnAlt] = splitCmciErrorMessage(error.mMessage);
               window.showErrorMessage(
-                `Perform OPEN on local file "${
-                  allSelectedNodes[parseInt(index)].localFile.file
+                `Perform OPEN on local file "${allSelectedNodes[parseInt(index)].localFile.file
                 }" failed: EXEC CICS command (${eibfnAlt}) RESP(${respAlt}) RESP2(${resp2})`
               );
             } else {
@@ -109,7 +103,7 @@ export function getOpenLocalFileCommand(tree: CICSTree, treeview: TreeView<any>)
   });
 }
 
-async function openLocalFile(session: imperative.AbstractSession, parms: { name: string; regionName: string; cicsPlex: string }): Promise<ICMCIApiResponse> {
+async function openLocalFile(session: imperative.AbstractSession, parms: { name: string; regionName: string; cicsPlex: string; }): Promise<ICMCIApiResponse> {
   const requestBody: any = {
     request: {
       action: {

--- a/packages/vsce/src/commands/phaseInCommand.ts
+++ b/packages/vsce/src/commands/phaseInCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSTree } from "../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSProgramTreeItem } from "../trees/treeItems/CICSProgramTreeItem";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
@@ -50,28 +49,23 @@ export function getPhaseInCommand(tree: CICSTree, treeview: TreeView<any>) {
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
           try {
             await performPhaseIn(currentNode.parentRegion.parentSession.session, {
               name: currentNode.program.program,
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
 
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             // @ts-ignore
             if (error.mMessage) {
               // @ts-ignore
               const [_, resp2, respAlt, eibfnAlt] = splitCmciErrorMessage(error.mMessage);
               window.showErrorMessage(
-                `Perform PHASEIN on Program "${
-                  allSelectedNodes[parseInt(index)].program.program
+                `Perform PHASEIN on Program "${allSelectedNodes[parseInt(index)].program.program
                 }" failed: EXEC CICS command (${eibfnAlt}) RESP(${respAlt}) RESP2(${resp2})`
               );
             } else {
@@ -116,7 +110,7 @@ export function getPhaseInCommand(tree: CICSTree, treeview: TreeView<any>) {
   });
 }
 
-async function performPhaseIn(session: imperative.AbstractSession, parms: { cicsPlex: string | null; regionName: string; name: string }) {
+async function performPhaseIn(session: imperative.AbstractSession, parms: { cicsPlex: string | null; regionName: string; name: string; }) {
   const requestBody: any = {
     request: {
       action: {

--- a/packages/vsce/src/commands/purgeTaskCommand.ts
+++ b/packages/vsce/src/commands/purgeTaskCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSTree } from "../trees/CICSTree";
-import * as https from "https";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
 import { CICSTaskTreeItem } from "../trees/treeItems/CICSTaskTreeItem";
 import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
@@ -55,8 +54,6 @@ export function getPurgeTaskCommand(tree: CICSTree, treeview: TreeView<any>) {
             });
             const currentNode = allSelectedNodes[parseInt(index)];
 
-            https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
             try {
               await purgeTask(
                 currentNode.parentRegion.parentSession.session,
@@ -67,19 +64,16 @@ export function getPurgeTaskCommand(tree: CICSTree, treeview: TreeView<any>) {
                 },
                 purgeType
               );
-              https.globalAgent.options.rejectUnauthorized = undefined;
               if (!parentRegions.includes(currentNode.parentRegion)) {
                 parentRegions.push(currentNode.parentRegion);
               }
             } catch (error) {
-              https.globalAgent.options.rejectUnauthorized = undefined;
               // @ts-ignore
               if (error.mMessage) {
                 // @ts-ignore
                 const [_, resp2, respAlt, eibfnAlt] = splitCmciErrorMessage(error.mMessage);
                 window.showErrorMessage(
-                  `Perform ${purgeType?.toUpperCase()} on CICSTask "${
-                    allSelectedNodes[parseInt(index)].task.task
+                  `Perform ${purgeType?.toUpperCase()} on CICSTask "${allSelectedNodes[parseInt(index)].task.task
                   }" failed: EXEC CICS command (${eibfnAlt}) RESP(${respAlt}) RESP2(${resp2})`
                 );
               } else {
@@ -136,7 +130,7 @@ export function getPurgeTaskCommand(tree: CICSTree, treeview: TreeView<any>) {
  */
 async function purgeTask(
   session: imperative.AbstractSession,
-  parms: { name: string; regionName: string; cicsPlex: string },
+  parms: { name: string; regionName: string; cicsPlex: string; },
   purgeType: string
 ): Promise<ICMCIApiResponse> {
   const requestBody: any = {

--- a/packages/vsce/src/trees/CICSLibraryTree.ts
+++ b/packages/vsce/src/trees/CICSLibraryTree.ts
@@ -12,10 +12,10 @@
 import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSRegionTree } from "./CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { getIconPathInResources } from "../utils/profileUtils";
 import { CICSLibraryTreeItem } from "./treeItems/CICSLibraryTreeItem";
 import { toEscapedCriteriaString } from "../utils/filterUtils";
+import { toArray } from "../utils/commandUtils";
 
 export class CICSLibraryTree extends TreeItem {
   children: CICSLibraryTreeItem[] = [];
@@ -42,7 +42,6 @@ export class CICSLibraryTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
       const libraryResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSLibrary",
@@ -50,10 +49,7 @@ export class CICSLibraryTree extends TreeItem {
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
-      const librariesArray = Array.isArray(libraryResponse.response.records.cicslibrary)
-        ? libraryResponse.response.records.cicslibrary
-        : [libraryResponse.response.records.cicslibrary];
+      const librariesArray = toArray(libraryResponse.response.records.cicslibrary);
       this.label = `Libraries${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${librariesArray.length}]`;
       for (const library of librariesArray) {
         const newLibraryItem = new CICSLibraryTreeItem(library, this.parentRegion, this);
@@ -61,7 +57,6 @@ export class CICSLibraryTree extends TreeItem {
       }
       this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a library filter to narrow search`);
       } else if (this.children.length === 0) {

--- a/packages/vsce/src/trees/CICSLocalFileTree.ts
+++ b/packages/vsce/src/trees/CICSLocalFileTree.ts
@@ -13,9 +13,9 @@ import { TreeItemCollapsibleState, TreeItem, window, workspace } from "vscode";
 import { CICSLocalFileTreeItem } from "./treeItems/CICSLocalFileTreeItem";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
 import { CICSRegionTree } from "./CICSRegionTree";
-import * as https from "https";
 import { toEscapedCriteriaString } from "../utils/filterUtils";
 import { getIconPathInResources } from "../utils/profileUtils";
+import { toArray } from "../utils/commandUtils";
 
 export class CICSLocalFileTree extends TreeItem {
   children: CICSLocalFileTreeItem[] = [];
@@ -46,7 +46,6 @@ export class CICSLocalFileTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
       const localFileResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSLocalFile",
@@ -54,10 +53,7 @@ export class CICSLocalFileTree extends TreeItem {
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
-      const localFileArray = Array.isArray(localFileResponse.response.records.cicslocalfile)
-        ? localFileResponse.response.records.cicslocalfile
-        : [localFileResponse.response.records.cicslocalfile];
+      const localFileArray = toArray(localFileResponse.response.records.cicslocalfile);
       this.label = `Local Files${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${localFileArray.length}]`;
       for (const localFile of localFileArray) {
         const newLocalFileItem = new CICSLocalFileTreeItem(localFile, this.parentRegion, this);
@@ -65,7 +61,6 @@ export class CICSLocalFileTree extends TreeItem {
       }
       this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       // @ts-ignore
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a local file filter to narrow search`);

--- a/packages/vsce/src/trees/CICSPlexTree.ts
+++ b/packages/vsce/src/trees/CICSPlexTree.ts
@@ -71,14 +71,12 @@ export class CICSPlexTree extends TreeItem {
    */
   public async loadOnlyRegion() {
     const plexProfile = this.getProfile();
-    https.globalAgent.options.rejectUnauthorized = plexProfile.profile.rejectUnauthorized;
     const session = this.getParent().getSession();
     const regionsObtained = await getResource(session, {
       name: "CICSRegion",
       cicsPlex: plexProfile.profile.cicsPlex,
       regionName: plexProfile.profile.regionName,
     });
-    https.globalAgent.options.rejectUnauthorized = undefined;
     const newRegionTree = new CICSRegionTree(
       plexProfile.profile.regionName,
       regionsObtained.response.records.cicsregion,

--- a/packages/vsce/src/trees/CICSProgramTree.ts
+++ b/packages/vsce/src/trees/CICSProgramTree.ts
@@ -13,9 +13,9 @@ import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSProgramTreeItem } from "./treeItems/CICSProgramTreeItem";
 import { CICSRegionTree } from "./CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { getDefaultProgramFilter, toEscapedCriteriaString } from "../utils/filterUtils";
 import { getIconPathInResources } from "../utils/profileUtils";
+import { toArray } from "../utils/commandUtils";
 export class CICSProgramTree extends TreeItem {
   children: CICSProgramTreeItem[] = [];
   parentRegion: CICSRegionTree;
@@ -41,7 +41,6 @@ export class CICSProgramTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
       const programResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSProgram",
@@ -49,10 +48,7 @@ export class CICSProgramTree extends TreeItem {
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
-      const programsArray = Array.isArray(programResponse.response.records.cicsprogram)
-        ? programResponse.response.records.cicsprogram
-        : [programResponse.response.records.cicsprogram];
+      const programsArray = toArray(programResponse.response.records.cicsprogram);
       this.label = `Programs${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${programsArray.length}]`;
       for (const program of programsArray) {
         const newProgramItem = new CICSProgramTreeItem(program, this.parentRegion, this);
@@ -60,7 +56,6 @@ export class CICSProgramTree extends TreeItem {
       }
       this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a program filter to narrow search`);
       } else if (this.children.length === 0) {

--- a/packages/vsce/src/trees/CICSRegionsContainer.ts
+++ b/packages/vsce/src/trees/CICSRegionsContainer.ts
@@ -16,7 +16,7 @@ import { CICSTree } from "./CICSTree";
 import { ProfileManagement } from "../utils/profileManagement";
 import { getIconPathInResources } from "../utils/profileUtils";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
+import { toArray } from "../utils/commandUtils";
 
 export class CICSRegionsContainer extends TreeItem {
   children: CICSRegionTree[];
@@ -61,18 +61,14 @@ export class CICSRegionsContainer extends TreeItem {
   public async loadRegionsInCICSGroup(tree: CICSTree) {
     const parentPlex = this.getParent();
     const plexProfile = parentPlex.getProfile();
-    https.globalAgent.options.rejectUnauthorized = plexProfile.profile.rejectUnauthorized;
     const session = parentPlex.getParent().getSession();
     const regionsObtained = await getResource(session, {
       name: "CICSManagedRegion",
       cicsPlex: plexProfile.profile.cicsPlex,
       regionName: plexProfile.profile.regionName,
     });
-    https.globalAgent.options.rejectUnauthorized = undefined;
     this.clearChildren();
-    const regionsArray = Array.isArray(regionsObtained.response.records.cicsmanagedregion)
-      ? regionsObtained.response.records.cicsmanagedregion
-      : [regionsObtained.response.records.cicsmanagedregion];
+    const regionsArray = toArray(regionsObtained.response.records.cicsmanagedregion);
     this.addRegionsUtility(regionsArray);
     // Keep container open after label change
     this.collapsibleState = TreeItemCollapsibleState.Expanded;

--- a/packages/vsce/src/trees/CICSTaskTree.ts
+++ b/packages/vsce/src/trees/CICSTaskTree.ts
@@ -12,10 +12,10 @@
 import { TreeItemCollapsibleState, TreeItem, window, workspace } from "vscode";
 import { CICSRegionTree } from "./CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { toEscapedCriteriaString } from "../utils/filterUtils";
 import { getIconPathInResources } from "../utils/profileUtils";
 import { CICSTaskTreeItem } from "./treeItems/CICSTaskTreeItem";
+import { toArray } from "../utils/commandUtils";
 
 export class CICSTaskTree extends TreeItem {
   children: CICSTaskTreeItem[] = [];
@@ -46,7 +46,6 @@ export class CICSTaskTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
       const taskResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSTASK",
@@ -54,11 +53,8 @@ export class CICSTaskTree extends TreeItem {
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
 
-      const tasksArray = Array.isArray(taskResponse.response.records.cicstask)
-        ? taskResponse.response.records.cicstask
-        : [taskResponse.response.records.cicstask];
+      const tasksArray = toArray(taskResponse.response.records.cicstask);
       this.label = `Tasks${this.activeTransactionFilter ? ` (${this.activeTransactionFilter}) ` : " "}[${tasksArray.length}]`;
       for (const task of tasksArray) {
         const newTaskItem = new CICSTaskTreeItem(task, this.parentRegion, this);
@@ -72,7 +68,6 @@ export class CICSTaskTree extends TreeItem {
       }
       this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a task filter to narrow search`);
       } else if (this.children.length === 0) {

--- a/packages/vsce/src/trees/CICSTransactionTree.ts
+++ b/packages/vsce/src/trees/CICSTransactionTree.ts
@@ -13,9 +13,9 @@ import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSTransactionTreeItem } from "./treeItems/CICSTransactionTreeItem";
 import { CICSRegionTree } from "./CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { getDefaultTransactionFilter, toEscapedCriteriaString } from "../utils/filterUtils";
 import { getIconPathInResources } from "../utils/profileUtils";
+import { toArray } from "../utils/commandUtils";
 
 export class CICSTransactionTree extends TreeItem {
   children: CICSTransactionTreeItem[] = [];
@@ -42,7 +42,6 @@ export class CICSTransactionTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
       const transactionResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSLocalTransaction",
@@ -50,10 +49,7 @@ export class CICSTransactionTree extends TreeItem {
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
-      const transactionArray = Array.isArray(transactionResponse.response.records.cicslocaltransaction)
-        ? transactionResponse.response.records.cicslocaltransaction
-        : [transactionResponse.response.records.cicslocaltransaction];
+      const transactionArray = toArray(transactionResponse.response.records.cicslocaltransaction);
       this.label = `Transactions${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${transactionArray.length}]`;
       for (const transaction of transactionArray) {
         const newTransactionItem = new CICSTransactionTreeItem(transaction, this.parentRegion, this);
@@ -61,7 +57,6 @@ export class CICSTransactionTree extends TreeItem {
       }
       this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       // @ts-ignore
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a transaction filter to narrow search`);

--- a/packages/vsce/src/trees/CICSTree.ts
+++ b/packages/vsce/src/trees/CICSTree.ts
@@ -28,7 +28,6 @@ import { addProfileHtml } from "../utils/webviewHTML";
 import { CICSPlexTree } from "./CICSPlexTree";
 import { CICSRegionTree } from "./CICSRegionTree";
 import { CICSSessionTree } from "./CICSSessionTree";
-import * as https from "https";
 import { getIconPathInResources, missingSessionParameters, promptCredentials } from "../utils/profileUtils";
 import { Gui, imperative } from "@zowe/zowe-explorer-api";
 
@@ -229,15 +228,12 @@ export class CICSTree implements TreeDataProvider<CICSSessionTree> {
                 protocol: profile.profile.protocol,
               });
               try {
-                https.globalAgent.options.rejectUnauthorized = profile.profile.rejectUnauthorized;
-
                 const regionsObtained = await getResource(session, {
                   name: "CICSRegion",
                   regionName: item.regions[0].applid,
                 });
                 // 200 OK received
                 newSessionTree.setAuthorized();
-                https.globalAgent.options.rejectUnauthorized = undefined;
                 const newRegionTree = new CICSRegionTree(
                   item.regions[0].applid,
                   regionsObtained.response.records.cicsregion,
@@ -247,7 +243,6 @@ export class CICSTree implements TreeDataProvider<CICSSessionTree> {
                 );
                 newSessionTree.addRegion(newRegionTree);
               } catch (error) {
-                https.globalAgent.options.rejectUnauthorized = undefined;
                 console.log(error);
               }
             } else {
@@ -274,7 +269,6 @@ export class CICSTree implements TreeDataProvider<CICSSessionTree> {
           }
           this._onDidChangeTreeData.fire(undefined);
         } catch (error) {
-          https.globalAgent.options.rejectUnauthorized = undefined;
           // Change session tree icon to disconnected upon error
           newSessionTree = new CICSSessionTree(profile, getIconPathInResources("profile-disconnected-dark.svg", "profile-disconnected-light.svg"));
           // If method was called when expanding profile

--- a/packages/vsce/src/trees/treeItems/CICSLibraryTreeItem.ts
+++ b/packages/vsce/src/trees/treeItems/CICSLibraryTreeItem.ts
@@ -12,10 +12,10 @@
 import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSRegionTree } from "../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { getIconPathInResources } from "../../utils/profileUtils";
 import { CICSLibraryDatasets } from "./CICSLibraryDatasets";
 import { toEscapedCriteriaString } from "../../utils/filterUtils";
+import { toArray } from "../../utils/commandUtils";
 
 export class CICSLibraryTreeItem extends TreeItem {
   children: CICSLibraryDatasets[] = [];
@@ -58,7 +58,6 @@ export class CICSLibraryTreeItem extends TreeItem {
 
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
       const libraryResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "cicslibrarydatasetname",
@@ -66,27 +65,21 @@ export class CICSLibraryTreeItem extends TreeItem {
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
-      const datasetArray = Array.isArray(libraryResponse.response.records.cicslibrarydatasetname)
-        ? libraryResponse.response.records.cicslibrarydatasetname
-        : [libraryResponse.response.records.cicslibrarydatasetname];
-      this.label = `${this.library.name}${this.parentRegion.parentPlex ? ` (${this.library.eyu_cicsname})` : ""}${
-        this.activeFilter ? ` (${this.activeFilter}) ` : " "
-      }[${datasetArray.length}]`;
+      const datasetArray = toArray(libraryResponse.response.records.cicslibrarydatasetname);
+      this.label = `${this.library.name}${this.parentRegion.parentPlex ? ` (${this.library.eyu_cicsname})` : ""}${this.activeFilter ? ` (${this.activeFilter}) ` : " "
+        }[${datasetArray.length}]`;
       for (const dataset of datasetArray) {
         const newDatasetItem = new CICSLibraryDatasets(dataset, this.parentRegion, this); //this=CICSLibraryTreeItem
         this.addDataset(newDatasetItem);
       }
       this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a datasets filter to narrow search`);
       } else if (this.children.length === 0) {
         window.showInformationMessage(`No datasets found`);
-        this.label = `${this.library.name}${this.parentRegion.parentPlex ? ` (${this.library.eyu_cicsname})` : ""}${
-          this.activeFilter ? ` (${this.activeFilter}) ` : " "
-        }[0]`;
+        this.label = `${this.library.name}${this.parentRegion.parentPlex ? ` (${this.library.eyu_cicsname})` : ""}${this.activeFilter ? ` (${this.activeFilter}) ` : " "
+          }[0]`;
       } else {
         window.showErrorMessage(
           `Something went wrong when fetching datasets - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(

--- a/packages/vsce/src/trees/treeItems/web/CICSPipelineTree.ts
+++ b/packages/vsce/src/trees/treeItems/web/CICSPipelineTree.ts
@@ -13,7 +13,6 @@ import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSPipelineTreeItem } from "./treeItems/CICSPipelineTreeItem";
 import { CICSRegionTree } from "../../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { toEscapedCriteriaString } from "../../../utils/filterUtils";
 import { getIconPathInResources } from "../../../utils/profileUtils";
 export class CICSPipelineTree extends TreeItem {
@@ -41,7 +40,6 @@ export class CICSPipelineTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
       const pipelineResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSPipeline",
@@ -49,10 +47,7 @@ export class CICSPipelineTree extends TreeItem {
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
-      const pipelinesArray = Array.isArray(pipelineResponse.response.records.cicspipeline)
-        ? pipelineResponse.response.records.cicspipeline
-        : [pipelineResponse.response.records.cicspipeline];
+      const pipelinesArray = toArray(pipelineResponse.response.records.cicspipeline);
       this.label = `Pipelines${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${pipelinesArray.length}]`;
       for (const pipeline of pipelinesArray) {
         const newPipelineItem = new CICSPipelineTreeItem(pipeline, this.parentRegion, this);
@@ -61,7 +56,6 @@ export class CICSPipelineTree extends TreeItem {
       }
       this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a Pipeline filter to narrow search`);
       } else if (this.children.length === 0) {

--- a/packages/vsce/src/trees/treeItems/web/CICSTCPIPServiceTree.ts
+++ b/packages/vsce/src/trees/treeItems/web/CICSTCPIPServiceTree.ts
@@ -13,7 +13,6 @@ import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSTCPIPServiceTreeItem } from "./treeItems/CICSTCPIPServiceTreeItem";
 import { CICSRegionTree } from "../../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { toEscapedCriteriaString } from "../../../utils/filterUtils";
 import { getIconPathInResources } from "../../../utils/profileUtils";
 export class CICSTCPIPServiceTree extends TreeItem {
@@ -41,7 +40,6 @@ export class CICSTCPIPServiceTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
       const tcpipsResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSTCPIPService",
@@ -49,10 +47,7 @@ export class CICSTCPIPServiceTree extends TreeItem {
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
-      const tcpipservicesArray = Array.isArray(tcpipsResponse.response.records.cicstcpipservice)
-        ? tcpipsResponse.response.records.cicstcpipservice
-        : [tcpipsResponse.response.records.cicstcpipservice];
+      const tcpipservicesArray = toArray(tcpipsResponse.response.records.cicstcpipservice);
       this.label = `TCPIP Services${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${tcpipservicesArray.length}]`;
       for (const tcpips of tcpipservicesArray) {
         const newTCPIPServiceItem = new CICSTCPIPServiceTreeItem(tcpips, this.parentRegion, this);
@@ -63,7 +58,6 @@ export class CICSTCPIPServiceTree extends TreeItem {
       }
       this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a TCPIPService filter to narrow search`);
       } else if (this.children.length === 0) {

--- a/packages/vsce/src/trees/treeItems/web/CICSURIMapTree.ts
+++ b/packages/vsce/src/trees/treeItems/web/CICSURIMapTree.ts
@@ -13,7 +13,6 @@ import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSURIMapTreeItem } from "./treeItems/CICSURIMapTreeItem";
 import { CICSRegionTree } from "../../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { toEscapedCriteriaString } from "../../../utils/filterUtils";
 import { getIconPathInResources } from "../../../utils/profileUtils";
 export class CICSURIMapTree extends TreeItem {
@@ -41,7 +40,6 @@ export class CICSURIMapTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
       const urimapResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSURIMap",
@@ -49,10 +47,7 @@ export class CICSURIMapTree extends TreeItem {
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
-      const urimapArray = Array.isArray(urimapResponse.response.records.cicsurimap)
-        ? urimapResponse.response.records.cicsurimap
-        : [urimapResponse.response.records.cicsurimap];
+      const urimapArray = toArray(urimapResponse.response.records.cicsurimap);
       this.label = `URI Maps${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${urimapArray.length}]`;
       for (const urimap of urimapArray) {
         const newURIMapItem = new CICSURIMapTreeItem(urimap, this.parentRegion, this);
@@ -63,7 +58,6 @@ export class CICSURIMapTree extends TreeItem {
       }
       this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a URIMap filter to narrow search`);
       } else if (this.children.length === 0) {

--- a/packages/vsce/src/trees/treeItems/web/CICSWebServiceTree.ts
+++ b/packages/vsce/src/trees/treeItems/web/CICSWebServiceTree.ts
@@ -13,7 +13,6 @@ import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSWebServiceTreeItem } from "./treeItems/CICSWebServiceTreeItem";
 import { CICSRegionTree } from "../../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { toEscapedCriteriaString } from "../../../utils/filterUtils";
 import { getIconPathInResources } from "../../../utils/profileUtils";
 export class CICSWebServiceTree extends TreeItem {
@@ -41,7 +40,6 @@ export class CICSWebServiceTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
       const webserviceResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSWebService",
@@ -49,10 +47,7 @@ export class CICSWebServiceTree extends TreeItem {
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
-      const webservicesArray = Array.isArray(webserviceResponse.response.records.cicswebservice)
-        ? webserviceResponse.response.records.cicswebservice
-        : [webserviceResponse.response.records.cicswebservice];
+      const webservicesArray = toArray(webserviceResponse.response.records.cicswebservice);
       this.label = `Web Services${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${webservicesArray.length}]`;
       for (const webservice of webservicesArray) {
         const newWebServiceItem = new CICSWebServiceTreeItem(webservice, this.parentRegion, this);
@@ -61,7 +56,6 @@ export class CICSWebServiceTree extends TreeItem {
       }
       this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a Web Services filter to narrow search`);
       } else if (this.children.length === 0) {

--- a/packages/vsce/src/utils/commandUtils.ts
+++ b/packages/vsce/src/utils/commandUtils.ts
@@ -62,3 +62,7 @@ export function splitCmciErrorMessage(message: any) {
   }
   return [resp, resp2, respAlt, eibfnAlt];
 }
+
+export function toArray<T>(input: T | [T]): [T] {
+  return Array.isArray(input) ? input : [input];
+}

--- a/packages/vsce/src/utils/profileManagement.ts
+++ b/packages/vsce/src/utils/profileManagement.ts
@@ -9,10 +9,9 @@
  *
  */
 
-import { getResource, ICMCIApiResponse } from "@zowe/cics-for-zowe-sdk";
+import { getCache, getResource, ICMCIApiResponse } from "@zowe/cics-for-zowe-sdk";
 import { Session } from "@zowe/imperative";
 import { imperative, Types, ZoweVsCodeExtension } from "@zowe/zowe-explorer-api";
-import axios, { AxiosRequestConfig } from "axios";
 import { window } from "vscode";
 import { xml2json } from "xml-js";
 import { CICSPlexTree } from "../trees/CICSPlexTree";
@@ -68,17 +67,6 @@ export class ProfileManagement {
   public static async getConfigInstance(): Promise<imperative.ProfileInfo> {
     const mProfileInfo = await ProfileManagement.getProfilesCache().getProfileInfo();
     return mProfileInfo;
-  }
-
-  /**
-   * Makes axios GET request with path and axios config object given
-   * @param path
-   * @param config
-   * @returns
-   */
-  public static async makeRequest(path: string, config: AxiosRequestConfig) {
-    const response = await axios.get(path, config);
-    return response;
   }
 
   public static cmciResponseXml2Json(data: string) {
@@ -330,21 +318,25 @@ export class ProfileManagement {
 
   public static async getCachedResources(profile: imperative.IProfileLoaded, cacheToken: string, resourceName: string, start = 1, increment = 800) {
     try {
-      const config: AxiosRequestConfig = {
-        baseURL: `${profile.profile.protocol}://${profile.profile.host}:${profile.profile.port}/CICSSystemManagement`,
-        auth: {
-          username: profile.profile.user,
-          password: profile.profile.password,
-        },
-      };
-      const allItemsResponse = await ProfileManagement.makeRequest(`/CICSResultCache/${cacheToken}/${start}/${increment}`, config);
-      if (allItemsResponse.status === 200) {
-        const jsonFromXml = ProfileManagement.cmciResponseXml2Json(allItemsResponse.data);
-        if (jsonFromXml.response && jsonFromXml.response.records && jsonFromXml.response.records[resourceName.toLowerCase()]) {
-          const recordAttributes = jsonFromXml.response.records[resourceName.toLowerCase()];
-          const recordAttributesArr = toArray(recordAttributes);
-          const returnedResources = recordAttributesArr.map((item: { _attributes: any; }) => item._attributes);
-          return returnedResources;
+      const session = new Session({
+        protocol: profile.profile.protocol,
+        hostname: profile.profile.host,
+        port: profile.profile.port,
+        type: "basic",
+        user: profile.profile.user,
+        password: profile.profile.password,
+        rejectUnauthorized: profile.profile && 'rejectUnauthorized' in profile.profile ? profile.profile.rejectUnauthorized : true,
+      });
+      const allItemsresponse = await getCache(session, {
+        cacheToken,
+        startIndex: start,
+        count: increment,
+      });
+
+      if (allItemsresponse.response.resultsummary.api_response1_alt === "OK") {
+        if (allItemsresponse.response && allItemsresponse.response.records && allItemsresponse.response.records[resourceName.toLowerCase()]) {
+          const recordAttributes = allItemsresponse.response.records[resourceName.toLowerCase()];
+          return toArray(recordAttributes);
         }
       }
     } catch (error) {

--- a/packages/vsce/src/utils/profileManagement.ts
+++ b/packages/vsce/src/utils/profileManagement.ts
@@ -9,20 +9,21 @@
  *
  */
 
-import { ProfilesCache, Types, ZoweVsCodeExtension, imperative } from "@zowe/zowe-explorer-api";
+import { getResource, ICMCIApiResponse } from "@zowe/cics-for-zowe-sdk";
+import { Session } from "@zowe/imperative";
+import { imperative, Types, ZoweVsCodeExtension } from "@zowe/zowe-explorer-api";
 import axios, { AxiosRequestConfig } from "axios";
 import { window } from "vscode";
 import { xml2json } from "xml-js";
-import cicsProfileMeta from "./profileDefinition";
-import * as https from "https";
 import { CICSPlexTree } from "../trees/CICSPlexTree";
-import { LoggerUtils } from "./loggerUtils";
+import { toArray } from "./commandUtils";
+import cicsProfileMeta from "./profileDefinition";
 
 export class ProfileManagement {
   private static zoweExplorerAPI = ZoweVsCodeExtension.getZoweExplorerApi();
   private static ProfilesCache = ProfileManagement.zoweExplorerAPI.getExplorerExtenderApi().getProfilesCache();
 
-  constructor() {}
+  constructor() { }
 
   public static apiDoesExist() {
     if (ProfileManagement.zoweExplorerAPI) {
@@ -90,63 +91,73 @@ export class ProfileManagement {
    * @returns Array of type InfoLoaded
    */
   public static async getPlexInfo(profile: imperative.IProfileLoaded): Promise<InfoLoaded[]> {
-    const config: AxiosRequestConfig = {
-      baseURL: `${profile.profile.protocol}://${profile.profile.host}:${profile.profile.port}/CICSSystemManagement`,
-      auth: {
-        username: profile.profile.user,
-        password: profile.profile.password,
-      },
-    };
-    const infoLoaded: InfoLoaded[] = [];
 
-    https.globalAgent.options.rejectUnauthorized = profile.profile.rejectUnauthorized;
+    const session = new Session({
+      protocol: profile.profile.protocol,
+      hostname: profile.profile.host,
+      port: profile.profile.port,
+      type: "basic",
+      user: profile.profile.user,
+      password: profile.profile.password,
+      rejectUnauthorized: profile.profile && 'rejectUnauthorized' in profile.profile ? profile.profile.rejectUnauthorized : true,
+    });
+
+    const infoLoaded: InfoLoaded[] = [];
 
     if (profile.profile.cicsPlex) {
       if (profile.profile.regionName) {
         /**
          * Both Supplied, no searching required - Only load 1 region
          */
-        const checkIfSystemGroup = await ProfileManagement.makeRequest(
-          `/CICSRegionGroup/${profile.profile.cicsPlex}/${profile.profile.regionName}?CRITERIA=(GROUP=${profile.profile.regionName})`,
-          config
-        );
-        const regionGroupJson = ProfileManagement.cmciResponseXml2Json(checkIfSystemGroup.data);
+        let checkIfSystemGroup: ICMCIApiResponse;
+        try {
+          checkIfSystemGroup = await getResource(session, {
+            name: "CICSRegionGroup",
+            cicsPlex: profile.profile.cicsPlex,
+            regionName: profile.profile.regionName,
+            criteria: `GROUP=${profile.profile.regionName}`,
+          });
+        } catch (error) {
+          if (error instanceof imperative.ImperativeError) {
+            if (!error.mDetails.msg.toUpperCase().includes("NODATA")) {
+              throw error;
+            }
+          }
+        }
+
         if (
-          regionGroupJson.response.resultsummary &&
-          regionGroupJson.response.resultsummary._attributes &&
-          regionGroupJson.response.resultsummary._attributes.recordcount !== "0"
+          checkIfSystemGroup &&
+          checkIfSystemGroup.response.resultsummary &&
+          checkIfSystemGroup.response.resultsummary.recordcount !== "0"
         ) {
           // CICSGroup
-          const singleGroupResponse = await ProfileManagement.makeRequest(
-            `/CICSManagedRegion/${profile.profile.cicsPlex}/${profile.profile.regionName}`,
-            config
-          );
-          const jsonFromXml = ProfileManagement.cmciResponseXml2Json(singleGroupResponse.data);
-          const allRegions = jsonFromXml.response.records.cicsmanagedregion.map((item: { _attributes: any }) => item._attributes);
+          const singleGroupResponse = await getResource(session, {
+            name: "CICSManagedRegion",
+            cicsPlex: profile.profile.cicsPlex,
+            regionName: profile.profile.regionName,
+          });
           infoLoaded.push({
             plexname: profile.profile.cicsPlex,
-            regions: [allRegions],
+            regions: toArray(singleGroupResponse.response.records.cicsmanagedregion),
             group: true,
           });
         } else {
           // Region
-          const singleRegionResponse = await ProfileManagement.makeRequest(
-            `/CICSManagedRegion/${profile.profile.cicsPlex}/${profile.profile.regionName}`,
-            config
-          );
-          const jsonFromXml = ProfileManagement.cmciResponseXml2Json(singleRegionResponse.data);
-          if (jsonFromXml.response.records && jsonFromXml.response.records.cicsmanagedregion) {
-            const singleRegion = jsonFromXml.response.records.cicsmanagedregion._attributes;
+          const singleRegionResponse = await getResource(session, {
+            name: "CICSManagedRegion",
+            cicsPlex: profile.profile.cicsPlex,
+            regionName: profile.profile.regionName,
+          });
+          if (singleRegionResponse.response.records && singleRegionResponse.response.records.cicsmanagedregion) {
             infoLoaded.push({
               plexname: profile.profile.cicsPlex,
-              regions: [singleRegion],
+              regions: toArray(singleRegionResponse.response.records.cicsmanagedregion),
               group: false,
             });
           } else {
             window.showErrorMessage(
               `Cannot find region ${profile.profile.regionName} in plex ${profile.profile.cicsPlex} for profile ${profile.name}`
             );
-            https.globalAgent.options.rejectUnauthorized = undefined;
             throw new Error("Region Not Found");
           }
         }
@@ -154,18 +165,18 @@ export class ProfileManagement {
         /**
          * Plex given - must search for regions
          */
-        const allRegionResponse = await ProfileManagement.makeRequest(`/CICSManagedRegion/${profile.profile.cicsPlex}`, config);
-        const jsonFromXml = ProfileManagement.cmciResponseXml2Json(allRegionResponse.data);
-        if (jsonFromXml.response.records && jsonFromXml.response.records.cicsmanagedregion) {
-          const allRegions = jsonFromXml.response.records.cicsmanagedregion.map((item: { _attributes: any }) => item._attributes);
+        const allRegionResponse = await getResource(session, {
+          name: "CICSManagedRegion",
+          cicsPlex: profile.profile.cicsPlex,
+        });
+        if (allRegionResponse.response.records && allRegionResponse.response.records.cicsmanagedregion) {
           infoLoaded.push({
             plexname: profile.profile.cicsPlex,
-            regions: allRegions,
+            regions: toArray(allRegionResponse.response.records.cicsmanagedregion),
             group: false,
           });
         } else {
           window.showErrorMessage(`Cannot find plex ${profile.profile.cicsPlex} for profile ${profile.name}`);
-          https.globalAgent.options.rejectUnauthorized = undefined;
           throw new Error("Plex Not Found");
         }
       }
@@ -174,18 +185,18 @@ export class ProfileManagement {
         /**
          * Region but no plex - Single region system, use that
          */
-        const singleRegionResponse = await ProfileManagement.makeRequest(`/CICSRegion/${profile.profile.regionName}`, config);
-        const jsonFromXml = ProfileManagement.cmciResponseXml2Json(singleRegionResponse.data);
-        if (jsonFromXml.response.records && jsonFromXml.response.records.cicsregion) {
-          const singleRegion = jsonFromXml.response.records.cicsregion._attributes;
+        const singleRegionResponse = await getResource(session, {
+          name: "CICSRegion",
+          regionName: profile.profile.regionName,
+        });
+        if (singleRegionResponse.response.records && singleRegionResponse.response.records.cicsregion) {
           infoLoaded.push({
             plexname: null,
-            regions: [singleRegion],
+            regions: toArray(singleRegionResponse.response.records.cicsregion),
             group: false,
           });
         } else {
           window.showErrorMessage(`Cannot find region ${profile.profile.regionName} for profile ${profile.name}`);
-          https.globalAgent.options.rejectUnauthorized = undefined;
           throw new Error("Region Not Found");
         }
       } else {
@@ -193,14 +204,14 @@ export class ProfileManagement {
          * Nothing given - Test if plex and find all info
          */
         try {
-          const testIfPlexResponse = await ProfileManagement.makeRequest(`/CICSCICSPlex`, config);
-          if (testIfPlexResponse.status === 200) {
+          const testIfPlexResponse = await getResource(session, {
+            name: "CICSCICSPlex",
+          });
+          if (testIfPlexResponse.response.resultsummary.api_response1_alt === "OK") {
             // Plex
-            const jsonFromXml = ProfileManagement.cmciResponseXml2Json(testIfPlexResponse.data);
-            if (jsonFromXml.response.records && jsonFromXml.response.records.cicscicsplex) {
-              const returnedPlexes = jsonFromXml.response.records.cicscicsplex.map((item: { _attributes: any }) => item._attributes);
-              const uniqueReturnedPlexes = returnedPlexes.filter(
-                (plex: any, index: number) => index === returnedPlexes.findIndex((found: any) => found.plexname === plex.plexname)
+            if (testIfPlexResponse.response.records && testIfPlexResponse.response.records.cicscicsplex) {
+              const uniqueReturnedPlexes = testIfPlexResponse.response.records.cicscicsplex.filter(
+                (plex: any, index: number) => index === testIfPlexResponse.response.records.cicscicsplex.findIndex((found: any) => found.plexname === plex.plexname)
               );
               for (const plex of uniqueReturnedPlexes) {
                 try {
@@ -217,37 +228,32 @@ export class ProfileManagement {
             }
           } else {
             // Not Plex
-            const singleRegion = await ProfileManagement.makeRequest(`/CICSRegion`, config);
-            const jsonFromXml = ProfileManagement.cmciResponseXml2Json(singleRegion.data);
-            const returnedRegion = jsonFromXml.response.records.cicsregion._attributes;
+            const singleRegion = await getResource(session, {
+              name: "CICSRegion",
+            });
             infoLoaded.push({
               plexname: null,
-              regions: [returnedRegion],
+              regions: toArray(singleRegion.response.records.cicsregion),
               group: false,
             });
           }
         } catch (error) {
           // Not Plex - Could be error
           try {
-            const singleRegion = await ProfileManagement.makeRequest(`/CICSRegion`, config);
-            const jsonFromXml = JSON.parse(xml2json(singleRegion.data, { compact: true, spaces: 4 }));
-            if (!jsonFromXml) {
-              throw error;
-            }
-            const returnedRegion = jsonFromXml.response.records.cicsregion._attributes;
+            const singleRegion = await getResource(session, {
+              name: "CICSRegion",
+            });
             infoLoaded.push({
               plexname: null,
-              regions: [returnedRegion],
+              regions: toArray(singleRegion.response.records.cicsregion),
               group: false,
             });
           } catch (e2) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             throw e2;
           }
         }
       }
     }
-    https.globalAgent.options.rejectUnauthorized = undefined;
     return infoLoaded;
   }
 
@@ -257,52 +263,62 @@ export class ProfileManagement {
   public static async getRegionInfoInPlex(plex: CICSPlexTree) {
     try {
       const profile = plex.getProfile();
-      const config: AxiosRequestConfig = {
-        baseURL: `${profile.profile.protocol}://${profile.profile.host}:${profile.profile.port}/CICSSystemManagement`,
-        auth: {
-          username: profile.profile.user,
-          password: profile.profile.password,
-        },
-      };
-      https.globalAgent.options.rejectUnauthorized = profile.profile.rejectUnauthorized;
-      const regionResponse = await ProfileManagement.makeRequest(`/CICSManagedRegion/${plex.getPlexName()}`, config);
-      https.globalAgent.options.rejectUnauthorized = undefined;
-      if (regionResponse.status === 200) {
-        const jsonFromXml = ProfileManagement.cmciResponseXml2Json(regionResponse.data);
-        if (jsonFromXml.response.records && jsonFromXml.response.records.cicsmanagedregion) {
-          const returnedRegions = jsonFromXml.response.records.cicsmanagedregion.map((item: { _attributes: any }) => item._attributes);
-          return returnedRegions;
+
+      const session = new Session({
+        protocol: profile.profile.protocol,
+        hostname: profile.profile.host,
+        port: profile.profile.port,
+        type: "basic",
+        user: profile.profile.user,
+        password: profile.profile.password,
+        rejectUnauthorized: profile.profile && 'rejectUnauthorized' in profile.profile ? profile.profile.rejectUnauthorized : true,
+      });
+
+      const regionResponse = await getResource(session, {
+        name: "CICSManagedRegion",
+        cicsPlex: plex.getPlexName(),
+      });
+      if (regionResponse.response.resultsummary.api_response1_alt === "OK") {
+        if (regionResponse.response.records && regionResponse.response.records.cicsmanagedregion) {
+          return regionResponse.response.records.cicsmanagedregion;
         }
       }
     } catch (error) {
       console.log(error);
-      window.showErrorMessage(`Cannot find plex ${plex.getPlexName()} for profile ${plex.getParent().label}`);
-      throw new Error("Plex Not Found");
+      if (error instanceof imperative.ImperativeError) {
+        if (error.mDetails.msg.includes("NOTAVAILABLE")) {
+          window.showErrorMessage(`No regions found for plex ${plex.getPlexName()} with profile ${plex.getParent().label}`);
+          throw new Error("No regions found");
+        }
+      }
+      window.showErrorMessage(`Error retrieving ManagedRegions for plex ${plex.getPlexName()} with profile ${plex.getParent().label}`, error.message);
+      throw new Error("Error retrieving ManagedRegions");
     }
   }
 
   public static async generateCacheToken(profile: imperative.IProfileLoaded, plexName: string, resourceName: string, criteria?: string, group?: string) {
     try {
-      const config: AxiosRequestConfig = {
-        baseURL: `${profile.profile.protocol}://${profile.profile.host}:${profile.profile.port}/CICSSystemManagement`,
-        auth: {
-          username: profile.profile.user,
-          password: profile.profile.password,
-        },
-        params: {
-          OVERRIDEWARNINGCOUNT: "YES",
-          CRITERIA: criteria,
-          NODISCARD: "",
-          SUMMONLY: "",
-        },
-      };
-      https.globalAgent.options.rejectUnauthorized = profile.profile.rejectUnauthorized;
-      const allProgramsResponse = await ProfileManagement.makeRequest(`/${resourceName}/${plexName}${group ? `/${group}` : ""}`, config);
-      https.globalAgent.options.rejectUnauthorized = undefined;
-      if (allProgramsResponse.status === 200) {
-        const jsonFromXml = ProfileManagement.cmciResponseXml2Json(allProgramsResponse.data);
-        if (jsonFromXml.response && jsonFromXml.response.resultsummary) {
-          const resultsSummary = jsonFromXml.response.resultsummary._attributes;
+      const session = new Session({
+        protocol: profile.profile.protocol,
+        hostname: profile.profile.host,
+        port: profile.profile.port,
+        type: "basic",
+        user: profile.profile.user,
+        password: profile.profile.password,
+        rejectUnauthorized: profile.profile && 'rejectUnauthorized' in profile.profile ? profile.profile.rejectUnauthorized : true,
+      });
+      const allProgramsResponse = await getResource(session, {
+        name: resourceName,
+        cicsPlex: plexName,
+        ...group ? { regionName: group } : {},
+        queryParams: {
+          summonly: true,
+          nodiscard: true,
+        }
+      });
+      if (allProgramsResponse.response.resultsummary.api_response1_alt === "OK") {
+        if (allProgramsResponse.response && allProgramsResponse.response.resultsummary) {
+          const resultsSummary = allProgramsResponse.response.resultsummary;
           return { cacheToken: resultsSummary.cachetoken, recordCount: resultsSummary.recordcount };
         }
       }
@@ -321,15 +337,13 @@ export class ProfileManagement {
           password: profile.profile.password,
         },
       };
-      https.globalAgent.options.rejectUnauthorized = profile.profile.rejectUnauthorized;
       const allItemsResponse = await ProfileManagement.makeRequest(`/CICSResultCache/${cacheToken}/${start}/${increment}`, config);
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (allItemsResponse.status === 200) {
         const jsonFromXml = ProfileManagement.cmciResponseXml2Json(allItemsResponse.data);
         if (jsonFromXml.response && jsonFromXml.response.records && jsonFromXml.response.records[resourceName.toLowerCase()]) {
           const recordAttributes = jsonFromXml.response.records[resourceName.toLowerCase()];
-          const recordAttributesArr = Array.isArray(recordAttributes) ? recordAttributes : [recordAttributes];
-          const returnedResources = recordAttributesArr.map((item: { _attributes: any }) => item._attributes);
+          const recordAttributesArr = toArray(recordAttributes);
+          const returnedResources = recordAttributesArr.map((item: { _attributes: any; }) => item._attributes);
           return returnedResources;
         }
       }


### PR DESCRIPTION
**What It Does**
Changes method of pulling data from CMCI from Axios HTTP requests to the CICS SDK's getResource and getCache methods. Removes the global rejectUnauthorized overrides which broke the other ZE sessions.

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
Resolves zowe/cics-for-zowe-client#159
Resolves zowe/cics-for-zowe-client#124